### PR TITLE
Add binary import/export support

### DIFF
--- a/vorgabe 11/src/operations.c
+++ b/vorgabe 11/src/operations.c
@@ -5,6 +5,41 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*
+ * Helper that resolves a path to an inode index. Returns -1 if the
+ * path could not be resolved.
+ */
+static int path_to_inode(file_system *fs, const char *path)
+{
+    if (fs == NULL || path == NULL || path[0] != '/')
+        return -1;
+
+    // copy path because strtok modifies the string
+    char tmp[strlen(path) + 1];
+    strcpy(tmp, path);
+
+    int current = fs->root_node;
+    char *token = strtok(tmp, "/");
+    while (token) {
+        int next = -1;
+        inode *node = &fs->inodes[current];
+        for (int i = 0; i < DIRECT_BLOCKS_COUNT; i++) {
+            int idx = node->direct_blocks[i];
+            if (idx == -1)
+                continue;
+            if (strncmp(fs->inodes[idx].name, token, NAME_MAX_LENGTH) == 0) {
+                next = idx;
+                break;
+            }
+        }
+        if (next == -1)
+            return -1;
+        current = next;
+        token = strtok(NULL, "/");
+    }
+    return current;
+}
+
 
 
 int
@@ -53,11 +88,93 @@ fs_rm(file_system *fs, char *path)
 int
 fs_import(file_system *fs, char *int_path, char *ext_path)
 {
-	return -1;
+    int inode_idx = path_to_inode(fs, int_path);
+    if (inode_idx < 0)
+        return -1;
+
+    inode *node = &fs->inodes[inode_idx];
+    if (node->n_type != reg_file)
+        return -1;
+
+    FILE *f = fopen(ext_path, "rb");
+    if (!f)
+        return -1;
+
+    fseek(f, 0, SEEK_END);
+    long fsize = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (fsize < 0) {
+        fclose(f);
+        return -1;
+    }
+
+    uint8_t *buffer = malloc((size_t)fsize);
+    if (!buffer) {
+        fclose(f);
+        return -1;
+    }
+    size_t r = fread(buffer, 1, (size_t)fsize, f);
+    fclose(f);
+    if (r != (size_t)fsize) {
+        free(buffer);
+        return -1;
+    }
+
+    node->size = (uint16_t)fsize;
+    size_t remaining = (size_t)fsize;
+    size_t offset = 0;
+    int d_idx = 0;
+    while (remaining > 0 && d_idx < DIRECT_BLOCKS_COUNT) {
+        int free_block = -1;
+        for (int i = 0; i < fs->s_block->num_blocks; i++) {
+            if (fs->free_list[i] == 1) {
+                free_block = i;
+                break;
+            }
+        }
+        if (free_block == -1) {
+            free(buffer);
+            return -1;
+        }
+
+        fs->free_list[free_block] = 0;
+        size_t to_copy = MIN(remaining, BLOCK_SIZE);
+        memcpy(fs->data_blocks[free_block].block, buffer + offset, to_copy);
+        fs->data_blocks[free_block].size = to_copy;
+        node->direct_blocks[d_idx++] = free_block;
+        offset += to_copy;
+        remaining -= to_copy;
+    }
+
+    free(buffer);
+    if (remaining > 0)
+        return -1;
+
+    return 0;
 }
 
 int
 fs_export(file_system *fs, char *int_path, char *ext_path)
 {
-	return -1;
+    int inode_idx = path_to_inode(fs, int_path);
+    if (inode_idx < 0)
+        return -1;
+
+    inode *node = &fs->inodes[inode_idx];
+    if (node->n_type != reg_file)
+        return -1;
+
+    FILE *f = fopen(ext_path, "wb");
+    if (!f)
+        return -1;
+
+    for (int i = 0; i < DIRECT_BLOCKS_COUNT; i++) {
+        int db = node->direct_blocks[i];
+        if (db == -1)
+            break;
+        fwrite(fs->data_blocks[db].block, fs->data_blocks[db].size, 1, f);
+    }
+
+    fclose(f);
+    return 0;
 }

--- a/vorgabe 11/tests/test_binary_import_export.py
+++ b/vorgabe 11/tests/test_binary_import_export.py
@@ -1,0 +1,20 @@
+import ctypes
+import hashlib
+from wrappers import *
+
+class Test_Binary_ImpExp:
+    def test_binary_import_export(self):
+        fs = setup(5)
+        fs = set_fil(name="fil1", inode=1, parent=0, parent_block=0, fs=fs)
+        data = bytes(range(256))
+        src = create_temp_binary_file(data=data, filename="temp_bin_in")
+        retval = libc.fs_import(ctypes.byref(fs), ctypes.c_char_p(b"/fil1"), ctypes.c_char_p(bytes(src, "utf-8")))
+        assert retval == 0
+        out = "temp_bin_out"
+        retval = libc.fs_export(ctypes.byref(fs), ctypes.c_char_p(b"/fil1"), ctypes.c_char_p(bytes(out, "utf-8")))
+        assert retval == 0
+        orig = read_temp_binary_file(src)
+        exported = read_temp_binary_file(out)
+        assert hashlib.md5(orig).digest() == hashlib.md5(exported).digest()
+        delete_temp_file(src)
+        delete_temp_file(out)

--- a/vorgabe 11/tests/wrappers.py
+++ b/vorgabe 11/tests/wrappers.py
@@ -119,8 +119,17 @@ def create_temp_file(data=SHORT_DATA,filename=DEFAULT_TEST_FILE_NAME):
     file.close
     return filename
 
+def create_temp_binary_file(data=b"\x00", filename=DEFAULT_TEST_FILE_NAME):
+    with open(filename, "wb") as f:
+        f.write(data)
+    return filename
+
 def read_temp_file(filename = DEFAULT_TEST_FILE_NAME):
     return open(filename,"r").read()
+
+def read_temp_binary_file(filename = DEFAULT_TEST_FILE_NAME):
+    with open(filename, "rb") as f:
+        return f.read()
 
 def delete_temp_file(filename=DEFAULT_TEST_FILE_NAME):
     os.remove(filename)


### PR DESCRIPTION
## Summary
- support path traversal in operations
- implement `fs_import` and `fs_export` for binary data
- add helpers for binary temp files
- add regression test covering binary import/export

## Testing
- `make test_binary_import_export`
- `make test_import`
- `make test_export`
- `make test` *(fails: mkdir, mkfile, readf, rm, writef unimplemented)*

------
https://chatgpt.com/codex/tasks/task_e_685abc9860ec83219713578a20a9ea50