### PR TITLE
Update free block accounting

### DIFF
--- a/vorgabe 11/lib/operations.h
+++ b/vorgabe 11/lib/operations.h
@@ -112,5 +112,25 @@ int fs_import(file_system *fs, char *int_path, char *ext_path);
  */
 int fs_export(file_system *fs, char *int_path, char *ext_path);
 
+/**
+ * Marks the given data block as used and decreases the free_blocks counter.
+ *
+ * @Returns 0 on success, -1 if the block number is invalid or already used.
+ */
+int allocate_data_block(file_system *fs, int block_num);
+
+/**
+ * Releases the given data block and increases the free_blocks counter.
+ *
+ * @Returns 0 on success, -1 if the block number is invalid or already free.
+ */
+int release_data_block(file_system *fs, int block_num);
+
+/**
+ * Removes an inode and all of its children recursively while freeing used
+ * data blocks.
+ */
+void remove_inode_recursive(file_system *fs, int inode_no);
+
 #define OPERATIONS_H
 #endif /* OPERATIONS_H */

--- a/vorgabe 11/src/operations.c
+++ b/vorgabe 11/src/operations.c
@@ -8,9 +8,68 @@
 
 
 int
+allocate_data_block(file_system *fs, int block_num)
+{
+        if (block_num < 0 || block_num >= fs->s_block->num_blocks) {
+                return -1;
+        }
+        if (fs->free_list[block_num] == 0) {
+                return -1;
+        }
+        fs->free_list[block_num] = 0;
+        if (fs->s_block->free_blocks > 0) {
+                fs->s_block->free_blocks--;
+        }
+        return 0;
+}
+
+int
+release_data_block(file_system *fs, int block_num)
+{
+        if (block_num < 0 || block_num >= fs->s_block->num_blocks) {
+                return -1;
+        }
+        if (fs->free_list[block_num] == 1) {
+                return -1;
+        }
+        fs->free_list[block_num] = 1;
+        fs->s_block->free_blocks++;
+        return 0;
+}
+
+void
+remove_inode_recursive(file_system *fs, int inode_no)
+{
+        inode *node = &fs->inodes[inode_no];
+
+        if (node->n_type == directory) {
+                for (int i = 0; i < DIRECT_BLOCKS_COUNT; i++) {
+                        int child = node->direct_blocks[i];
+                        if (child != -1) {
+                                remove_inode_recursive(fs, child);
+                                node->direct_blocks[i] = -1;
+                        }
+                }
+        } else if (node->n_type == reg_file) {
+                for (int i = 0; i < DIRECT_BLOCKS_COUNT; i++) {
+                        int block = node->direct_blocks[i];
+                        if (block != -1) {
+                                release_data_block(fs, block);
+                                node->direct_blocks[i] = -1;
+                        }
+                }
+        }
+
+        node->n_type = free_block;
+        node->size = 0;
+        memset(node->name, 0, NAME_MAX_LENGTH);
+        node->parent = -1;
+}
+
+int
 fs_mkdir(file_system *fs, char *path)
 {
-	return -1;
+        return -1;
 }
 
 int

--- a/vorgabe 11/tests/test_free_blocks.py
+++ b/vorgabe 11/tests/test_free_blocks.py
@@ -1,0 +1,20 @@
+import ctypes
+from wrappers import *
+
+class TestFreeBlocks:
+    def test_alloc_and_free(self):
+        fs = setup(5)
+        fs = set_fil(name="fil1", inode=1, parent=0, parent_block=0, fs=fs)
+        fs = set_data_block_with_string(block_num=0, string_data="abc", parent_inode=1, parent_block_num=0, fs=fs)
+        assert fs.s_block.contents.free_blocks == 4
+        fs = free_block(0, fs)
+        assert fs.s_block.contents.free_blocks == 5
+
+    def test_remove_inode_updates_counter(self):
+        fs = setup(5)
+        fs = set_fil(name="fil1", inode=1, parent=0, parent_block=0, fs=fs)
+        fs = set_data_block_with_string(block_num=0, string_data="abc", parent_inode=1, parent_block_num=0, fs=fs)
+        remove_inode_rec(1, fs)
+        assert fs.s_block.contents.free_blocks == 5
+        assert fs.inodes[1].n_type == NodeType.free_block
+

--- a/vorgabe 11/tests/wrappers.py
+++ b/vorgabe 11/tests/wrappers.py
@@ -54,6 +54,15 @@ class FileSystem(ctypes.Structure):
     ]
 
 
+# register helper functions from the C library
+libc.allocate_data_block.argtypes = [ctypes.POINTER(FileSystem), ctypes.c_int]
+libc.allocate_data_block.restype = ctypes.c_int
+libc.release_data_block.argtypes = [ctypes.POINTER(FileSystem), ctypes.c_int]
+libc.release_data_block.restype = ctypes.c_int
+libc.remove_inode_recursive.argtypes = [ctypes.POINTER(FileSystem), ctypes.c_int]
+libc.remove_inode_recursive.restype = None
+
+
 # creates a new filesystem using the C-Function
 def setup(fs_size):
     fsize= ctypes.c_int();
@@ -103,7 +112,7 @@ def set_data_block(block_num: int, data, data_size,parent_inode:int,parent_block
             i+=1
         else:
             break
-    fs.free_list[block_num] = 0
+    libc.allocate_data_block(ctypes.byref(fs), block_num)
 
     return fs
 
@@ -124,3 +133,13 @@ def read_temp_file(filename = DEFAULT_TEST_FILE_NAME):
 
 def delete_temp_file(filename=DEFAULT_TEST_FILE_NAME):
     os.remove(filename)
+
+
+def free_block(block_num: int, fs: FileSystem):
+    libc.release_data_block(ctypes.byref(fs), block_num)
+    return fs
+
+
+def remove_inode_rec(inode: int, fs: FileSystem):
+    libc.remove_inode_recursive(ctypes.byref(fs), inode)
+    return fs


### PR DESCRIPTION
## Summary
- expose helper functions for block allocation and release
- keep `free_blocks` in sync when blocks are allocated or freed
- add wrappers for new helpers and adjust block allocation helper
- add unit test checking `free_blocks` counter

## Testing
- `make test` *(fails: 31 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685abc9ae9148321b314c5774c804905