### PR TITLE
Add negative tests for import/export/cp

### DIFF
--- a/vorgabe 11/tests/test_export.py
+++ b/vorgabe 11/tests/test_export.py
@@ -15,6 +15,20 @@ class Test_Expo:
 
         delete_temp_file()
 
+    # exporting a non-existing file should return -1
+    def test_export_missing_internal(self):
+        fs = setup(5)
+        retval = libc.fs_export(ctypes.byref(fs), ctypes.c_char_p(b"/nofile"), ctypes.c_char_p(bytes(DEFAULT_TEST_FILE_NAME, "utf-8")))
+        assert retval == -1
+
+    # exporting to a path without space should also return -1
+    def test_export_insufficient_space(self):
+        fs = setup(5)
+        fs = set_fil(name="fil1",inode=1,parent=0,parent_block=0,fs=fs)
+        fs = set_data_block_with_string(block_num=0,string_data=SHORT_DATA,parent_inode=1,parent_block_num=0,fs=fs)
+        retval = libc.fs_export(ctypes.byref(fs), ctypes.c_char_p(b"/fil1"), ctypes.c_char_p(b"/dev/full"))
+        assert retval == -1
+
     def test_export_longer(self):
         fs = setup(5)
         fs = set_fil(name="fil1",inode=1,parent=0,parent_block=0,fs=fs)


### PR DESCRIPTION
## Summary
- add failing-path tests for `fs_import`
- cover missing source, existing dest and space errors for `fs_cp`
- add export tests for missing files and `/dev/full`

## Testing
- `make test` *(fails: 33 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685abcac250c8321b132c891235e9e3b