### PR TITLE
Implement allocate_data_block and expose in wrappers

### DIFF
--- a/vorgabe 11/lib/filesystem.h
+++ b/vorgabe 11/lib/filesystem.h
@@ -82,6 +82,13 @@ void inode_init(inode* i);
 int find_free_inode(file_system* fs);
 
 /*
+ * Reserve a free data block in the filesystem and return its index.
+ * The chosen block is cleared and marked as used in the free list.
+ * @return index of the allocated block or -1 if none is available.
+ */
+int allocate_data_block(file_system* fs);
+
+/*
 	* frees up memory
 */
 void cleanup(file_system* fs);

--- a/vorgabe 11/src/filesystem.c
+++ b/vorgabe 11/src/filesystem.c
@@ -138,12 +138,27 @@ int fs_dump(file_system *fs, const char *file_path){
 
 
 int find_free_inode(file_system* fs){
-	for (int i=0; i<fs->s_block->num_blocks; i++) {
-		if(fs->inodes[i].n_type==free_block){
-			return i;
-		}
-	}
-	return -1;
+        for (int i=0; i<fs->s_block->num_blocks; i++) {
+                if(fs->inodes[i].n_type==free_block){
+                        return i;
+                }
+        }
+        return -1;
+}
+
+int allocate_data_block(file_system *fs) {
+        for (int i = 0; i < fs->s_block->num_blocks; i++) {
+                if (fs->free_list[i] == 1) {
+                        fs->free_list[i] = 0;
+                        fs->s_block->free_blocks--;
+
+                        fs->data_blocks[i].size = 0;
+                        memset(fs->data_blocks[i].block, 0, BLOCK_SIZE);
+
+                        return i;
+                }
+        }
+        return -1;
 }
 
 

--- a/vorgabe 11/tests/test_allocate.py
+++ b/vorgabe 11/tests/test_allocate.py
@@ -1,0 +1,18 @@
+import ctypes
+from wrappers import *
+
+class TestAllocateBlock:
+    def test_allocate_simple(self):
+        fs = setup(5)
+        idx = libc.allocate_data_block(ctypes.byref(fs))
+        assert idx == 0
+        assert fs.free_list[idx] == 0
+        # block should be zeroed
+        data = bytes(fs.data_blocks[idx].block)
+        assert data == b"\x00" * BLOCK_SIZE
+        # next allocation should give next block
+        idx2 = libc.allocate_data_block(ctypes.byref(fs))
+        assert idx2 == 1
+        assert fs.free_list[idx2] == 0
+        assert fs.s_block.contents.free_blocks == 3
+

--- a/vorgabe 11/tests/wrappers.py
+++ b/vorgabe 11/tests/wrappers.py
@@ -2,6 +2,7 @@ import enum
 import ctypes
 import os
 libc = ctypes.CDLL("./build/operations.so")
+libc.allocate_data_block.restype = ctypes.c_int
 
 BLOCK_SIZE = 1024
 NAME_MAX_LENGTH = 32
@@ -53,6 +54,8 @@ class FileSystem(ctypes.Structure):
         ("root_node", ctypes.c_int)
     ]
 
+
+libc.allocate_data_block.argtypes = [ctypes.POINTER(FileSystem)]
 
 # creates a new filesystem using the C-Function
 def setup(fs_size):


### PR DESCRIPTION
## Summary
- implement new `allocate_data_block` helper in `filesystem.c`
- document and expose the function via `filesystem.h`
- wire `allocate_data_block` to python wrappers
- add simple test exercising the new function

## Testing
- `mkdir -p build && make test` *(fails: 31 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685ac782166083218b24692564c7b285