### PR TITLE
Implement core filesystem operations

### DIFF
--- a/vorgabe 11/src/operations.c
+++ b/vorgabe 11/src/operations.c
@@ -134,3 +134,217 @@ int fs_mkfile(file_system *fs, char *path_and_name)
 
     return 0;
 }
+
+// Copies an inode recursively
+static int copy_inode_recursive(file_system *fs, int src_idx, int dst_parent, const char *name)
+{
+    int new_idx = find_free_inode(fs);
+    if (new_idx < 0) return -1;
+
+    inode_init(&fs->inodes[new_idx]);
+    fs->inodes[new_idx].n_type = fs->inodes[src_idx].n_type;
+    strncpy(fs->inodes[new_idx].name, name, NAME_MAX_LENGTH);
+    fs->inodes[new_idx].parent = dst_parent;
+    if (add_child_inode(fs, dst_parent, new_idx) != 0) return -1;
+
+    if (fs->inodes[src_idx].n_type == reg_file) {
+        for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+            int b = fs->inodes[src_idx].direct_blocks[i];
+            if (b != -1) {
+                int nb = find_free_block(fs);
+                if (nb < 0) return -1;
+                fs->free_list[nb] = 0;
+                fs->s_block->free_blocks--;
+                fs->data_blocks[nb].size = fs->data_blocks[b].size;
+                memcpy(fs->data_blocks[nb].block, fs->data_blocks[b].block, fs->data_blocks[b].size);
+                fs->inodes[new_idx].direct_blocks[i] = nb;
+            }
+        }
+        fs->inodes[new_idx].size = fs->inodes[src_idx].size;
+    } else if (fs->inodes[src_idx].n_type == directory) {
+        for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+            int child = fs->inodes[src_idx].direct_blocks[i];
+            if (child != -1) {
+                copy_inode_recursive(fs, child, new_idx, fs->inodes[child].name);
+            }
+        }
+    }
+    return 0;
+}
+
+int fs_cp(file_system *fs, char *src_path, char *dst_path_and_name)
+{
+    if (!fs || !src_path || !dst_path_and_name) return -1;
+    int src_idx = find_inode_by_path(fs, src_path);
+    if (src_idx < 0) return -1;
+
+    char parent_path[strlen(dst_path_and_name) + 1];
+    const char *name;
+    if (split_path(dst_path_and_name, parent_path, &name) != 0) return -1;
+    int dst_parent = find_inode_by_path(fs, parent_path);
+    if (dst_parent < 0 || fs->inodes[dst_parent].n_type != directory) return -1;
+    for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+        int ch = fs->inodes[dst_parent].direct_blocks[i];
+        if (ch != -1 && strncmp(fs->inodes[ch].name, name, NAME_MAX_LENGTH) == 0)
+            return -2;
+    }
+    return copy_inode_recursive(fs, src_idx, dst_parent, name);
+}
+
+char *fs_list(file_system *fs, char *path)
+{
+    int idx = find_inode_by_path(fs, path);
+    if (idx < 0 || fs->inodes[idx].n_type != directory) return NULL;
+    size_t alloc = DIRECT_BLOCKS_COUNT * (NAME_MAX_LENGTH + 5);
+    char *out = malloc(alloc);
+    if (!out) return NULL;
+    out[0] = '\0';
+    for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+        int child = fs->inodes[idx].direct_blocks[i];
+        if (child != -1) {
+            const char *prefix = fs->inodes[child].n_type == directory ? "DIR " : "FIL ";
+            strncat(out, prefix, alloc - strlen(out) - 1);
+            strncat(out, fs->inodes[child].name, alloc - strlen(out) - 1);
+            strncat(out, "\n", alloc - strlen(out) - 1);
+        }
+    }
+    return out;
+}
+
+int fs_writef(file_system *fs, char *filename, char *text)
+{
+    if (!fs || !filename || !text) return -1;
+    int idx = find_inode_by_path(fs, filename);
+    if (idx < 0 || fs->inodes[idx].n_type != reg_file) return -1;
+    size_t remaining = strlen(text);
+    size_t written = 0;
+    for (int i = 0; i < DIRECT_BLOCKS_COUNT && remaining > 0; ++i) {
+        int blk = fs->inodes[idx].direct_blocks[i];
+        if (blk == -1) {
+            blk = find_free_block(fs);
+            if (blk == -1) return -2;
+            fs->free_list[blk] = 0;
+            fs->s_block->free_blocks--;
+            fs->inodes[idx].direct_blocks[i] = blk;
+            fs->data_blocks[blk].size = 0;
+        }
+        size_t off = fs->data_blocks[blk].size;
+        size_t space = BLOCK_SIZE - off;
+        size_t to_copy = MIN(remaining, space);
+        memcpy(fs->data_blocks[blk].block + off, text + written, to_copy);
+        fs->data_blocks[blk].size += to_copy;
+        written += to_copy;
+        remaining -= to_copy;
+        if (remaining == 0) break;
+    }
+    if (remaining > 0) return -2;
+    fs->inodes[idx].size = 0;
+    for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+        int b = fs->inodes[idx].direct_blocks[i];
+        if (b != -1) fs->inodes[idx].size += fs->data_blocks[b].size;
+    }
+    return (int)written;
+}
+
+uint8_t *fs_readf(file_system *fs, char *filename, int *file_size)
+{
+    if (!fs || !filename || !file_size) return NULL;
+    int idx = find_inode_by_path(fs, filename);
+    if (idx < 0 || fs->inodes[idx].n_type != reg_file) {
+        *file_size = 0;
+        return NULL;
+    }
+    int total = fs->inodes[idx].size;
+    *file_size = total;
+    if (total == 0) return NULL;
+    uint8_t *buf = malloc(total);
+    if (!buf) return NULL;
+    int pos = 0;
+    for (int i = 0; i < DIRECT_BLOCKS_COUNT && pos < total; ++i) {
+        int b = fs->inodes[idx].direct_blocks[i];
+        if (b != -1) {
+            memcpy(buf + pos, fs->data_blocks[b].block, fs->data_blocks[b].size);
+            pos += fs->data_blocks[b].size;
+        }
+    }
+    return buf;
+}
+
+static void rm_inode_recursive(file_system *fs, int idx)
+{
+    inode *node = &fs->inodes[idx];
+    if (node->n_type == directory) {
+        for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+            int child = node->direct_blocks[i];
+            if (child != -1) {
+                rm_inode_recursive(fs, child);
+            }
+        }
+    } else if (node->n_type == reg_file) {
+        for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+            int b = node->direct_blocks[i];
+            if (b != -1) {
+                fs->free_list[b] = 1;
+                fs->s_block->free_blocks++;
+                fs->data_blocks[b].size = 0;
+                node->direct_blocks[i] = -1;
+            }
+        }
+        node->size = 0;
+    }
+    int parent = node->parent;
+    if (parent != -1) {
+        for (int i = 0; i < DIRECT_BLOCKS_COUNT; ++i) {
+            if (fs->inodes[parent].direct_blocks[i] == idx)
+                fs->inodes[parent].direct_blocks[i] = -1;
+        }
+    }
+    inode_init(node);
+}
+
+int fs_rm(file_system *fs, char *path)
+{
+    if (!fs || !path) return -1;
+    int idx = find_inode_by_path(fs, path);
+    if (idx < 0 || idx == fs->root_node) return -1;
+    rm_inode_recursive(fs, idx);
+    return 0;
+}
+
+int fs_import(file_system *fs, char *int_path, char *ext_path)
+{
+    if (!fs || !int_path || !ext_path) return -1;
+    FILE *f = fopen(ext_path, "rb");
+    if (!f) return -1;
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    rewind(f);
+    char *buf = NULL;
+    if (size > 0) {
+        buf = malloc(size + 1);
+        fread(buf, 1, size, f);
+        buf[size] = '\0';
+    }
+    fclose(f);
+    if (size > 0) {
+        int res = fs_writef(fs, int_path, buf);
+        free(buf);
+        return res < 0 ? -1 : 0;
+    }
+    return 0;
+}
+
+int fs_export(file_system *fs, char *int_path, char *ext_path)
+{
+    if (!fs || !int_path || !ext_path) return -1;
+    int idx = find_inode_by_path(fs, int_path);
+    if (idx < 0 || fs->inodes[idx].n_type != reg_file) return -1;
+    int size = 0;
+    uint8_t *data = fs_readf(fs, int_path, &size);
+    FILE *f = fopen(ext_path, "wb");
+    if (!f) { free(data); return -1; }
+    if (size > 0 && data) fwrite(data, 1, size, f);
+    fclose(f);
+    free(data);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement remaining filesystem operations in `operations.c`
- update data blocks and freelist when modifying files
- support copying files/directories, listing, reading/writing, removing, import and export

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783cfb217c832190006f08dad4aa62